### PR TITLE
CI: add workflow for uplaoding the docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Push Docker images to Docker Hub 
+
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  multiple-registries:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks.
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # 1.6.0
+
+      - name: Cache Docker layers
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # 2.1.7
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # 1.10.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # 2.7.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ github.event.repository.full_name }}:latest
+            ${{ github.event.repository.full_name }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Push Docker images to Docker Hub
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   multiple-registries:


### PR DESCRIPTION
@ErikSchierboom from my understanding, there is no need to upload ECR being as the docker images are built in the GitHub actions which have access to the docker hub images and this image wouldn't need to be stored on ECR.

I assume you'd want to add a CODEOWNERS file

Also, could think correct keys and stuff be added to this repo?