### PR TITLE
Build: remove AWS from deploy targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build-and-push-image:
     uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
+    with:
+      aws_ecr: false
     secrets:
       AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
       AWS_REGION: ${{secrets.AWS_REGION}}


### PR DESCRIPTION
It is unnecessary to push to AWS as this docker image is only used to build the nim tooling in the github actions
