### PR TITLE
github(workflows): remove version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
     - name: Build Image
       run: docker build -t "exercism/nim-docker-base:${NIM_VERSION}" .

--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -7,9 +7,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250 # 1.6.0
+        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250
         with:
           dockerfile: Dockerfile


### PR DESCRIPTION
These comments can be helpful, but dependabot doesn't support them -
they have to be updated manually in dependabot PRs. To remove the burden
of keeping the comments in sync, let's just remove them.

With this PR:

```console
$ git grep --break --heading '@' -- .github/workflows
.github/workflows/ci.yml
20:    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579

.github/workflows/deploy.yml
14:    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main

.github/workflows/lint_dockerfile.yml
10:        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
13:        uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250

.github/workflows/sync:labels.yml
19:    uses: exercism/github-actions/.github/workflows/labels.yml@main
```