### PR TITLE
ci: bump Nim from 1.6.0 to 1.6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 env:
-  NIM_VERSION: 1.6.0
+  NIM_VERSION: 1.6.4
 
 
 jobs:


### PR DESCRIPTION
Commit 0ad461c92d47 bumped the version in `bin/install_nim.sh`, but not
in the CI workflow.