### PR TITLE
Dockerfile: bump Alpine from 3.14.2 to 3.15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=alpine
-ARG IMAGE=3.14.2@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a
+ARG IMAGE=3.15.3@sha256:1e014f84205d569a5cc3be4e108ca614055f7e21d11928946113ab3f36054801
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
Release posts:
- https://alpinelinux.org/posts/Alpine-3.14.3-released.html
- https://alpinelinux.org/posts/Alpine-3.15.0-released.html
- https://alpinelinux.org/posts/Alpine-3.15.1-released.html
- https://alpinelinux.org/posts/Alpine-3.15.2-released.html
- https://alpinelinux.org/posts/Alpine-3.12.11-3.13.9-3.14.5-3.15.3-released.html