### PR TITLE
.github(workflows), install_nim: bump Nim from 1.6.4 to 1.6.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 env:
-  NIM_VERSION: 1.6.4
+  NIM_VERSION: 1.6.10
 
 
 jobs:

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='1.6.4'
+readonly NIM_VERSION='1.6.10'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
See the release blog posts

- https://nim-lang.org/blog/2022/05/05/version-166-released.html
- https://nim-lang.org/blog/2022/09/27/version-168-released.html
- https://nim-lang.org/blog/2022/11/23/version-1610-released.html

and changes since 1.6.4:

- https://github.com/nim-lang/Nim/compare/v1.6.4...v1.6.6
- https://github.com/nim-lang/Nim/compare/v1.6.6...v1.6.8
- https://github.com/nim-lang/Nim/compare/v1.6.8...v1.6.10

---

Double-checking that this PR bumps it everywhere:

```console
$ git rev-parse --short HEAD
66e0120
$ git grep --break --heading '1\.6'
.github/workflows/ci.yml
11:  NIM_VERSION: 1.6.10

bin/install_nim.sh
6:readonly NIM_VERSION='1.6.10'
```