### PR TITLE
.github, install_nim: bump Nim from 1.6.10 to 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 env:
-  NIM_VERSION: 1.6.10
+  NIM_VERSION: 2.0.0
 
 
 jobs:

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='1.6.10'
+readonly NIM_VERSION='2.0.0'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
See the Nim 2.0 [blog post][1] and [changelog][2].

[1]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html
[2]: https://github.com/nim-lang/Nim/blob/a488067a4130f029000be4550a0fb1b39e0e9e7c/changelogs/changelog_2_0_0_details.md

Closes: #38