### PR TITLE
Dockerfile: bump Alpine from 3.17.0 to 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=alpine
-ARG IMAGE=3.17.0@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c
+ARG IMAGE=3.18.2@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
Release notes:

- https://alpinelinux.org/posts/Alpine-3.17.1-released.html
- https://alpinelinux.org/posts/Alpine-3.17.2-released.html
- https://alpinelinux.org/posts/Alpine-3.17.3-released.html
- https://alpinelinux.org/posts/Alpine-3.18.0-released.htm
- https://alpinelinux.org/posts/Alpine-3.15.9-3.16.6-3.17.4-3.18.2-released.html

(It looks like there was no proper 3.18.1 release).

Closes: #39

---

Previous bump: https://github.com/exercism/nim-docker-base/pull/28
Base alpine image: https://hub.docker.com/layers/library/alpine/3.18.2/images/sha256-25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70