### PR TITLE
Dockerfile: bump Alpine from 3.18.2 to 3.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=alpine
-ARG IMAGE=3.18.2@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
+ARG IMAGE=3.19.1@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
Release notes, in chronological order:

- https://alpinelinux.org/posts/Alpine-3.15.10-3.16.7-3.17.5-3.18.3-released.html
- https://alpinelinux.org/posts/Alpine-3.18.4-released.html
- https://alpinelinux.org/posts/Alpine-3.15.11-3.16.8-3.17.6-3.18.5-released.html
- https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html
- https://alpinelinux.org/posts/Alpine-3.19.0-released.html
- https://alpinelinux.org/posts/Alpine-3.19.1-released.html

---

Previous bump: https://github.com/exercism/nim-docker-base/pull/41