### PR TITLE
.github, install_nim: bump Nim from 2.0.2 to 2.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 env:
-  NIM_VERSION: 2.0.2
+  NIM_VERSION: 2.0.4
 
 
 jobs:

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='2.0.2'
+readonly NIM_VERSION='2.0.4'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
See the [release post][1] and [new commits][2].

[1]: https://nim-lang.org/blog/2024/04/16/versions-1620-204-released.html
[2]: https://github.com/nim-lang/Nim/compare/v2.0.2...v2.0.4

---

Previous bump: https://github.com/exercism/nim-docker-base/pull/47