### PR TITLE
.github(lint_dockerfile): bump Ubuntu from 20.04 to 24.04

### DIFF
--- a/.github/workflows/lint_dockerfile.yml
+++ b/.github/workflows/lint_dockerfile.yml
@@ -3,7 +3,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fix workflow error:

>This is a scheduled Ubuntu 20.04 retirement.
>
> Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://www.github.com/actions/runner-images/issues/11101