### PR TITLE
.github, install_nim: bump Nim from 2.0.4 to 2.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 env:
-  NIM_VERSION: 2.0.4
+  NIM_VERSION: 2.2.4
 
 
 jobs:

--- a/bin/install_nim.sh
+++ b/bin/install_nim.sh
@@ -3,7 +3,7 @@
 set -ex
 
 readonly ARCHIVE_FILENAME='nim.tar.xz'
-readonly NIM_VERSION='2.0.4'
+readonly NIM_VERSION='2.2.4'
 readonly BUILD_DIR='/build/nim'
 readonly INSTALL_DIR='/nim/'
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
See the release posts:

- https://nim-lang.org/blog/2024/06/17/version-206-released.html
- https://nim-lang.org/blog/2024/07/03/version-208-released.html
- https://nim-lang.org/blog/2024/10/02/nim-220-2010.html
- https://nim-lang.org/blog/2025/02/05/nim-222.html
- https://nim-lang.org/blog/2025/04/22/nim-224-2016.html

---

Previous bump: https://github.com/exercism/nim-docker-base/pull/49