### PR TITLE
Dockerfile: bump Alpine from 3.19.1 to 3.22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=alpine
-ARG IMAGE=3.19.1@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0
+ARG IMAGE=3.22.0@sha256:08001109a7d679fe33b04fa51d681bd40b975d8f5cea8c3ef6c0eccb6a7338ce
 FROM ${REPO}:${IMAGE} AS base
 # We can't reliably pin the package versions on Alpine, so we ignore the linter warning.
 # See https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996


### PR DESCRIPTION
Release notes for the major releases:

- https://alpinelinux.org/posts/Alpine-3.20.0-released.html
- https://alpinelinux.org/posts/Alpine-3.21.0-released.html
- https://alpinelinux.org/posts/Alpine-3.22.0-released.html

---

Previous bump: https://github.com/exercism/nim-docker-base/pull/46